### PR TITLE
Update WKWebViewJavascriptBridgeBase.swift

### DIFF
--- a/WKWebViewJavascriptBridge/WKWebViewJavascriptBridgeBase.swift
+++ b/WKWebViewJavascriptBridge/WKWebViewJavascriptBridgeBase.swift
@@ -76,10 +76,10 @@ public class WKWebViewJavascriptBridgeBase: NSObject {
                     }
                 }
                 
-                guard let handlerName = message["handlerName"] as? String else { return }
+                guard let handlerName = message["handlerName"] as? String else { continue }
                 guard let handler = messageHandlers[handlerName] else {
                     log("NoHandlerException, No handler for message from JS: \(message)")
-                    return
+                    continue
                 }
                 handler(message["data"] as? [String : Any], callback)
             }


### PR DESCRIPTION
fixed: When a handler is not registered, other calls in the queue cannot be executed