### PR TITLE
Consume startupMessageQueue after bridge injection

### DIFF
--- a/WKWebViewJavascriptBridge/WKWebViewJavascriptBridge.swift
+++ b/WKWebViewJavascriptBridge/WKWebViewJavascriptBridge.swift
@@ -79,8 +79,8 @@ public class WKWebViewJavascriptBridge: NSObject {
 }
 
 extension WKWebViewJavascriptBridge: WKWebViewJavascriptBridgeBaseDelegate {
-    func evaluateJavascript(javascript: String) {
-        webView?.evaluateJavaScript(javascript, completionHandler: nil)
+    func evaluateJavascript(javascript: String, completion: CompletionHandler) {
+        webView?.evaluateJavaScript(javascript, completionHandler: completion)
     }
 }
 


### PR DESCRIPTION
Previously `startupMessageQueue` in `WKWebViewJavascriptBridgeBase` was never consumed.
After checking `WebViewJavascriptBridge`, I think it should be consumed after bridge injection.